### PR TITLE
Revert "CC-1984: Change uncomment code text (2nd try)"

### DIFF
--- a/compiled_starters/go/cmd/mygrep/main.go
+++ b/compiled_starters/go/cmd/mygrep/main.go
@@ -49,7 +49,7 @@ func matchLine(line []byte, pattern string) (bool, error) {
 	// You can use print statements as follows for debugging, they'll be visible when running tests.
 	fmt.Println("Logs from your program will appear here!")
 
-	// Uncomment the code below to pass the first stage the first stage
+	// Uncomment this to pass the first stage
 	// ok = bytes.ContainsAny(line, pattern)
 
 	return ok, nil

--- a/compiled_starters/python/app/main.py
+++ b/compiled_starters/python/app/main.py
@@ -22,7 +22,7 @@ def main():
     # You can use print statements as follows for debugging, they'll be visible when running tests.
     print("Logs from your program will appear here!")
 
-    # Uncomment the code below to pass the first stage the first stage
+    # Uncomment this block to pass the first stage
     # if match_pattern(input_line, pattern):
     #     exit(0)
     # else:

--- a/compiled_starters/rust/src/main.rs
+++ b/compiled_starters/rust/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
 
     io::stdin().read_line(&mut input_line).unwrap();
 
-    // Uncomment the code below to pass the first stage the first stage
+    // Uncomment this block to pass the first stage
     // if match_pattern(&input_line, &pattern) {
     //     process::exit(0)
     // } else {

--- a/solutions/go/01-oq4/diff/cmd/mygrep/main.go.diff
+++ b/solutions/go/01-oq4/diff/cmd/mygrep/main.go.diff
@@ -27,7 +27,7 @@
 -	// You can use print statements as follows for debugging, they'll be visible when running tests.
 -	fmt.Println("Logs from your program will appear here!")
 -
--	// Uncomment the code below to pass the first stage the first stage
+-	// Uncomment this to pass the first stage
 -	// ok = bytes.ContainsAny(line, pattern)
 +	ok = bytes.ContainsAny(line, pattern)
 

--- a/solutions/python/01-oq4/diff/app/main.py.diff
+++ b/solutions/python/01-oq4/diff/app/main.py.diff
@@ -23,7 +23,7 @@
 -    # You can use print statements as follows for debugging, they'll be visible when running tests.
 -    print("Logs from your program will appear here!")
 -
--    # Uncomment the code below to pass the first stage the first stage
+-    # Uncomment this block to pass the first stage
 -    # if match_pattern(input_line, pattern):
 -    #     exit(0)
 -    # else:

--- a/solutions/rust/01-oq4/diff/src/main.rs.diff
+++ b/solutions/rust/01-oq4/diff/src/main.rs.diff
@@ -26,7 +26,7 @@
 
      io::stdin().read_line(&mut input_line).unwrap();
 
--    // Uncomment the code below to pass the first stage the first stage
+-    // Uncomment this block to pass the first stage
 -    // if match_pattern(&input_line, &pattern) {
 -    //     process::exit(0)
 -    // } else {

--- a/starter_templates/go/code/cmd/mygrep/main.go
+++ b/starter_templates/go/code/cmd/mygrep/main.go
@@ -49,7 +49,7 @@ func matchLine(line []byte, pattern string) (bool, error) {
 	// You can use print statements as follows for debugging, they'll be visible when running tests.
 	fmt.Println("Logs from your program will appear here!")
 
-	// Uncomment the code below to pass the first stage the first stage
+	// Uncomment this to pass the first stage
 	// ok = bytes.ContainsAny(line, pattern)
 
 	return ok, nil

--- a/starter_templates/python/code/app/main.py
+++ b/starter_templates/python/code/app/main.py
@@ -22,7 +22,7 @@ def main():
     # You can use print statements as follows for debugging, they'll be visible when running tests.
     print("Logs from your program will appear here!")
 
-    # Uncomment the code below to pass the first stage the first stage
+    # Uncomment this block to pass the first stage
     # if match_pattern(input_line, pattern):
     #     exit(0)
     # else:

--- a/starter_templates/rust/code/src/main.rs
+++ b/starter_templates/rust/code/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
 
     io::stdin().read_line(&mut input_line).unwrap();
 
-    // Uncomment the code below to pass the first stage the first stage
+    // Uncomment this block to pass the first stage
     // if match_pattern(&input_line, &pattern) {
     //     process::exit(0)
     // } else {


### PR DESCRIPTION
Reverts codecrafters-io/build-your-own-writers-stg#25

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies the "uncomment" instruction comments in Go/Python/Rust starters and updates solutions to run the match logic with proper exits, removing debug logs.
> 
> - **Starters (Go/Python/Rust)**:
>   - Clarify instructional comments to "Uncomment this block to pass the first stage" in `compiled_starters/*` and `starter_templates/*`.
> - **Solutions**:
>   - Go: enable `ok = bytes.ContainsAny(line, pattern)` in `solutions/go/01-oq4/diff/cmd/mygrep/main.go.diff`; remove debug prints.
>   - Python: execute `match_pattern` and exit with appropriate status in `solutions/python/01-oq4/diff/app/main.py.diff`; remove debug prints.
>   - Rust: execute `match_pattern` and exit accordingly in `solutions/rust/01-oq4/diff/src/main.rs.diff`; remove debug prints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e679ac56a1c27e9ac5478f0c5d3453355e13f2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->